### PR TITLE
Updated links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 
 A personal collection of jscad scripts.
 
-  * https://openjscad.org/#https://raw.githubusercontent.com/peter-hartmann/jscad-snippets/main/two-arms.js
-  * https://openjscad.org/#https://raw.githubusercontent.com/peter-hartmann/jscad-snippets/main/parallel.js
-  * https://openjscad.org/#https://raw.githubusercontent.com/peter-hartmann/jscad-snippets/main/armuno2.js
+  * https://3d.hrg.hr/jscad/V1/#https://raw.githubusercontent.com/peter-hartmann/jscad-snippets/main/two-arms.js
+  * https://3d.hrg.hr/jscad/V1/#https://raw.githubusercontent.com/peter-hartmann/jscad-snippets/main/parallel.js
+  * https://3d.hrg.hr/jscad/V1/#https://raw.githubusercontent.com/peter-hartmann/jscad-snippets/main/armuno2.js
 
 ## Animation example
 
-https://openjscad.org/#https://erasta.github.io/openjscad_animation/clock_anim.js
+https://3d.hrg.hr/jscad/V1/#https://erasta.github.io/openjscad_animation/clock_anim.js


### PR DESCRIPTION
Updated links to reflect the new domain for OpenJSCAD v1 as discussed in https://github.com/jscad/OpenJSCAD.org/discussions/883.